### PR TITLE
Patch out default use of message switch in xcp-idl

### DIFF
--- a/SOURCES/xcp-idl-dont-use-switch
+++ b/SOURCES/xcp-idl-dont-use-switch
@@ -1,0 +1,13 @@
+diff --git a/lib/xcp_client.ml b/lib/xcp_client.ml
+index 390dfde..9783125 100644
+--- a/lib/xcp_client.ml
++++ b/lib/xcp_client.ml
+@@ -22,7 +22,7 @@ let colon = Re_str.regexp "[:]"
+ let get_user_agent () = Sys.argv.(0)
+ 
+ let switch_port = ref 8080
+-let use_switch = ref true 
++let use_switch = ref false
+ 
+ let switch_rpc queue_name string_of_call response_of_string =
+ 	let c = Protocol_unix.Client.connect !switch_port in

--- a/xcp-idl.spec.in
+++ b/xcp-idl.spec.in
@@ -1,11 +1,12 @@
 Name:           ocaml-xcp-idl
 Version:        @VERSION@
-Release:        0
+Release:        1
 Summary:        Common interface definitions for XCP services
 License:        LGPL
 Group:          Development/Other
 URL:            https://github.com/xen-org/xcp-idl/archive/xcp-idl-%{version}.tar.gz
 Source0:        @SOURCE@
+Patch1:		xcp-idl-dont-use-switch
 BuildRoot:      %{_tmppath}/%{name}-%{version}-%{release}
 BuildRequires:  ocaml ocaml-findlib ocaml-camlp4-devel
 BuildRequires:  ocaml-cohttp-devel ocaml-xmlm-devel ocaml-rpc-devel ocaml-syslog-devel message-switch-devel cmdliner-devel ocaml-fd-send-recv-devel ocaml-xcp-rrd-devel
@@ -38,6 +39,7 @@ developing applications that use %{name}.
 
 %prep
 %setup -q -n @PREFIX@
+%patch1 -p1
 
 %build
 ocaml setup.ml -configure --destdir %{buildroot}/%{_libdir}/ocaml


### PR DESCRIPTION
Signed-off-by: Jon Ludlam jonathan.ludlam@eu.citrix.com
