### PR TITLE
xenopsd: only run the configure script if it exists

### DIFF
--- a/xenopsd.spec.in
+++ b/xenopsd.spec.in
@@ -70,7 +70,9 @@ Simple VM manager for Xen using libxenlight
 %setup -q -n %{name}-%{version}
 
 %build
-./configure
+if [ -e ./configure ]; then
+  ./configure
+fi
 make
 
 %install


### PR DESCRIPTION
In the current iteration, make compiles a configure program.
The configure script might come back in future, so let's be
future-proof.

Signed-off-by: David Scott dave.scott@eu.citrix.com
