### PR TITLE
EA-1168: Install xenopsd-xenlight by default, but don't enable it

### DIFF
--- a/install.json
+++ b/install.json
@@ -5,6 +5,7 @@
     ,{ 'package-name' : 'squeezed' }
     ,{ 'package-name' : 'xenopsd' }
     ,{ 'package-name' : 'xenopsd-xc' }
+    ,{ 'package-name' : 'xenopsd-xenlight' }
     ,{ 'package-name' : 'xenops-cli' }
     ,{ 'package-name' : 'sm-cli' }
     ,{ 'package-name' : 'vhdd' }

--- a/xenopsd.spec.in
+++ b/xenopsd.spec.in
@@ -180,7 +180,7 @@ fi
 %{_sysconfdir}/init.d/xenopsd-xenlight
 
 %post xenlight
-/sbin/chkconfig --add xenopsd-xenlight
+#/sbin/chkconfig --add xenopsd-xenlight
 
 %preun xenlight
 if [ $1 -eq 0 ]; then


### PR DESCRIPTION
Signed-off-by: Euan Harris euan.harris@citrix.com
