### PR TITLE
ocaml-xen-lowlevel-libs: 'make build' rather than 'make'

### DIFF
--- a/ocaml-xen-lowlevel-libs.spec.in
+++ b/ocaml-xen-lowlevel-libs.spec.in
@@ -29,7 +29,7 @@ developing applications that use %{name}.
 %build
 make configure
 ./configure --disable-xenctrl
-make
+make build
 
 %install
 rm -rf %{buildroot}


### PR DESCRIPTION
Something is wrong with the docs build, but we're not packaging
these anyway.

Signed-off-by: David Scott dave.scott@eu.citrix.com
