### PR TITLE
install.json: JSON strings must be enclosed in double quotes

### DIFF
--- a/install.json
+++ b/install.json
@@ -1,13 +1,13 @@
 [
-     { 'package-name' : 'forkexecd' }
-    ,{ 'package-name' : 'xcp-networkd' }
-    ,{ 'package-name' : 'xcp-rrdd' }
-    ,{ 'package-name' : 'squeezed' }
-    ,{ 'package-name' : 'xenopsd' }
-    ,{ 'package-name' : 'xenopsd-xc' }
-    ,{ 'package-name' : 'xenopsd-xenlight' }
-    ,{ 'package-name' : 'xenops-cli' }
-    ,{ 'package-name' : 'sm-cli' }
-    ,{ 'package-name' : 'vhdd' }
-    ,{ 'package-name' : 'vhd-tool' }
+     { "package-name" : "forkexecd" }
+    ,{ "package-name" : "xcp-networkd" }
+    ,{ "package-name" : "xcp-rrdd" }
+    ,{ "package-name" : "squeezed" }
+    ,{ "package-name" : "xenopsd" }
+    ,{ "package-name" : "xenopsd-xc" }
+    ,{ "package-name" : "xenopsd-xenlight" }
+    ,{ "package-name" : "xenops-cli" }
+    ,{ "package-name" : "sm-cli" }
+    ,{ "package-name" : "vhdd" }
+    ,{ "package-name" : "vhd-tool" }
 ]


### PR DESCRIPTION
The JSON spec only accepts double-quoted strings.   Planex
now uses Python's JSON library, which enforces this requirement,
whereas the old demjson library did not.

Signed-off-by: Euan Harris euan.harris@citrix.com
