### PR TITLE
Define planex_version and planex_release

### DIFF
--- a/ffs.spec.in
+++ b/ffs.spec.in
@@ -1,6 +1,9 @@
+%define planex_version 0.0.0
+%define planex_release 1
+
 Name:           ffs
-Version:        @VERSION@
-Release:        1
+Version:        %{planex_version}
+Release:        %{planex_release}
 Summary:        The "flat file system" SR
 License:        LGPL
 Group:          Development/Other

--- a/forkexecd.spec.in
+++ b/forkexecd.spec.in
@@ -1,6 +1,9 @@
+%define planex_version 0.0.0
+%define planex_release 1
+
 Name:           forkexecd
-Version:        @VERSION@
-Release:        1
+Version:        %{planex_version}
+Release:        %{planex_release}
 Summary:        A subprocess management service
 License:        LGPL
 Group:          Development/Other

--- a/message-switch.spec.in
+++ b/message-switch.spec.in
@@ -1,6 +1,9 @@
+%define planex_version 0.0.0
+%define planex_release 1
+
 Name:           message-switch
-Version:        @VERSION@
-Release:        0
+Version:        %{planex_version}
+Release:        %{planex_release}
 Summary:        A store and forward message switch
 License:        FreeBSD
 Group:          Development/Other

--- a/ocaml-camldm.spec.in
+++ b/ocaml-camldm.spec.in
@@ -1,6 +1,9 @@
+%define planex_version 0.0.0
+%define planex_release 1
+
 Name:           ocaml-camldm
-Version:        @VERSION@
-Release:        1
+Version:        %{planex_version}
+Release:        %{planex_release}
 Summary:        OCaml bindings to device mapper
 License:        LGPL2.1 + OCaml linking exception
 Group:          Development/Other

--- a/ocaml-cdrom.spec.in
+++ b/ocaml-cdrom.spec.in
@@ -1,6 +1,9 @@
+%define planex_version 0.0.0
+%define planex_release 1
+
 Name:           ocaml-cdrom
-Version:        @VERSION@
-Release:        2
+Version:        %{planex_version}
+Release:        %{planex_release}
 Summary:        Query the state of CDROM devices
 License:        LGPL2.1 + OCaml linking exception
 Group:          Development/Other

--- a/ocaml-crc.spec.in
+++ b/ocaml-crc.spec.in
@@ -1,8 +1,10 @@
+%define planex_version 0.0.0
+%define planex_release 1
 %define debug_package %{nil}
 
 Name:           ocaml-crc
-Version:        @VERSION@
-Release:        1
+Version:        %{planex_version}
+Release:        %{planex_release}
 Summary:        CRC implementation for OCaml
 License:        ISC
 Group:          Development/Other

--- a/ocaml-fd-send-recv.spec.in
+++ b/ocaml-fd-send-recv.spec.in
@@ -1,6 +1,9 @@
+%define planex_version 0.0.0
+%define planex_release 1
+
 Name:           ocaml-fd-send-recv
-Version:        @VERSION@
-Release:        1
+Version:        %{planex_version}
+Release:        %{planex_release}
 Summary:        Bindings to sendmsg/recvmsg for fd passing under Linux
 License:        LGPL
 Group:          Development/Other

--- a/ocaml-libvhd.spec.in
+++ b/ocaml-libvhd.spec.in
@@ -1,6 +1,9 @@
+%define planex_version 0.0.0
+%define planex_release 1
+
 Name:           ocaml-libvhd
-Version:        @VERSION@
-Release:        1
+Version:        %{planex_version}
+Release:        %{planex_release}
 Summary:        vhd manipulation via libvhd
 License:        BSD3
 Group:          Development/Other

--- a/ocaml-mlvm.spec.in
+++ b/ocaml-mlvm.spec.in
@@ -1,6 +1,9 @@
+%define planex_version 0.0.0
+%define planex_release 1
+
 Name:           ocaml-mlvm
-Version:        @VERSION@
-Release:        1
+Version:        %{planex_version}
+Release:        %{planex_release}
 Summary:        OCaml implementation of LVM
 License:        LGPL2.1 + OCaml linking exception
 Group:          Development/Other

--- a/ocaml-netdev.spec.in
+++ b/ocaml-netdev.spec.in
@@ -1,6 +1,9 @@
+%define planex_version 0.0.0
+%define planex_release 1
+
 Name:           ocaml-netdev
-Version:        @VERSION@
-Release:        1
+Version:        %{planex_version}
+Release:        %{planex_release}
 Summary:        Manipulate Linux bridges, network devices and openvswitch instances in OCaml
 License:        LGPL
 Group:          Development/Other

--- a/ocaml-opasswd.spec.in
+++ b/ocaml-opasswd.spec.in
@@ -1,6 +1,9 @@
+%define planex_version 0.0.0
+%define planex_release 1
+
 Name:           ocaml-opasswd
-Version:        @VERSION@
-Release:        0
+Version:        %{planex_version}
+Release:        %{planex_release}
 Summary:        OCaml interface to the glibc passwd/shadow password functions
 License:        ISC
 Group:          Development/Other

--- a/ocaml-qmp.spec.in
+++ b/ocaml-qmp.spec.in
@@ -1,6 +1,9 @@
+%define planex_version 0.0.0
+%define planex_release 1
+
 Name:           ocaml-qmp
-Version:        @VERSION@
-Release:        0
+Version:        %{planex_version}
+Release:        %{planex_release}
 Summary:        Pure OCaml implementation of the Qemu Message Protocol (QMP)
 License:        LGPL2.1 + OCaml linking exception
 Group:          Development/Other

--- a/ocaml-rrd-transport.spec.in
+++ b/ocaml-rrd-transport.spec.in
@@ -1,8 +1,10 @@
+%define planex_version 0.0.0
+%define planex_release 1
 %define debug_package %{nil}
 
 Name:           ocaml-rrd-transport
-Version:        @VERSION@
-Release:        1
+Version:        %{planex_version}
+Release:        %{planex_release}
 Summary:        Shared-memory protocols for transmitting RRD data
 License:        LGPL2.1 + OCaml linking exception
 Group:          Development/Other

--- a/ocaml-sha.spec.in
+++ b/ocaml-sha.spec.in
@@ -1,6 +1,9 @@
+%define planex_version 0.0.0
+%define planex_release 1
+
 Name:           ocaml-sha
-Version:        @VERSION@
-Release:        0
+Version:        %{planex_version}
+Release:        %{planex_release}
 Summary:        OCaml SHA
 License:        LGPL2.1
 Group:          Development/Other

--- a/ocaml-stdext.spec.in
+++ b/ocaml-stdext.spec.in
@@ -1,6 +1,9 @@
+%define planex_version 0.0.0
+%define planex_release 1
+
 Name:           ocaml-stdext
-Version:        @VERSION@
-Release:        1
+Version:        %{planex_version}
+Release:        %{planex_release}
 Summary:        Deprecated misc library functions for OCaml
 License:        LGPL
 Group:          Development/Other

--- a/ocaml-tapctl.spec.in
+++ b/ocaml-tapctl.spec.in
@@ -1,6 +1,9 @@
+%define planex_version 0.0.0
+%define planex_release 1
+
 Name:           ocaml-tapctl
-Version:        @VERSION@
-Release:        0
+Version:        %{planex_version}
+Release:        %{planex_release}
 Summary:        Manipulate running tapdisk instances
 License:        LGPL
 Group:          Development/Other

--- a/ocaml-tar.spec.in
+++ b/ocaml-tar.spec.in
@@ -1,6 +1,9 @@
+%define planex_version 0.0.0
+%define planex_release 1
+
 Name:           ocaml-tar
-Version:        @VERSION@
-Release:        0
+Version:        %{planex_version}
+Release:        %{planex_release}
 Summary:        OCaml parser and printer for tar-format data
 License:        LGPL2.1 + OCaml linking exception
 Group:          Development/Other

--- a/ocaml-vhd.spec.in
+++ b/ocaml-vhd.spec.in
@@ -1,8 +1,10 @@
+%define planex_version 0.0.0
+%define planex_release 1
 %global debug_package %{nil}
 
 Name:           ocaml-vhd
-Version:        @VERSION@
-Release:        0
+Version:        %{planex_version}
+Release:        %{planex_release}
 Summary:        A pure OCaml library for reading, writing, streaming, converting vhd format files
 License:        LGPL2.1 + Ocaml linking exception
 Group:          Development/Other

--- a/ocaml-xcp-idl.spec.in
+++ b/ocaml-xcp-idl.spec.in
@@ -1,6 +1,9 @@
+%define planex_version 0.0.0
+%define planex_release 1
+
 Name:           ocaml-xcp-idl
-Version:        @VERSION@
-Release:        1
+Version:        %{planex_version}
+Release:        %{planex_release}
 Summary:        Common interface definitions for XCP services
 License:        LGPL
 Group:          Development/Other

--- a/ocaml-xcp-inventory.spec.in
+++ b/ocaml-xcp-inventory.spec.in
@@ -1,6 +1,9 @@
+%define planex_version 0.0.0
+%define planex_release 1
+
 Name:           ocaml-xcp-inventory
-Version:        @VERSION@
-Release:        1
+Version:        %{planex_version}
+Release:        %{planex_release}
 Summary:        OCaml library to read and write the XCP inventory file
 License:        LGPL2.1 + OCaml linking exception
 Group:          Development/Other

--- a/ocaml-xcp-rrd.spec.in
+++ b/ocaml-xcp-rrd.spec.in
@@ -1,6 +1,9 @@
+%define planex_version 0.0.0
+%define planex_release 1
+
 Name:           ocaml-xcp-rrd
-Version:        @VERSION@
-Release:        0
+Version:        %{planex_version}
+Release:        %{planex_release}
 Summary:        Round-Robin Datasources in OCaml
 License:        LGPL
 Group:          Development/Other

--- a/ocaml-xen-api-client.spec.in
+++ b/ocaml-xen-api-client.spec.in
@@ -1,6 +1,9 @@
+%define planex_version 0.0.0
+%define planex_release 1
+
 Name:           ocaml-xen-api-client
-Version:        @VERSION@
-Release:        0
+Version:        %{planex_version}
+Release:        %{planex_release}
 Summary:        XenServer XenAPI Client Library for OCaml
 License:        LGPLv2
 Group:          Development/Libraries

--- a/ocaml-xen-api-libs-transitional.spec.in
+++ b/ocaml-xen-api-libs-transitional.spec.in
@@ -1,6 +1,9 @@
+%define planex_version 0.0.0
+%define planex_release 1
+
 Name:           ocaml-xen-api-libs-transitional
-Version:        @VERSION@
-Release:        1
+Version:        %{planex_version}
+Release:        %{planex_release}
 Summary:        Deprecated standard library extension for OCaml.
 License:        LGPL2.1 + OCaml linking exception
 Group:          Development/Other

--- a/ocaml-xen-lowlevel-libs.spec.in
+++ b/ocaml-xen-lowlevel-libs.spec.in
@@ -1,6 +1,9 @@
+%define planex_version 0.0.0
+%define planex_release 1
+
 Name:           ocaml-xen-lowlevel-libs
-Version:        @VERSION@
-Release:        0
+Version:        %{planex_version}
+Release:        %{planex_release}
 Summary:        Xen hypercall bindings for OCaml
 License:        LGPL
 Group:          Development/Other

--- a/ocaml-xenops.spec.in
+++ b/ocaml-xenops.spec.in
@@ -1,6 +1,9 @@
+%define planex_version 0.0.0
+%define planex_release 1
+
 Name:           ocaml-xenops
-Version:        @VERSION@ 
-Release:        0
+Version:        %{planex_version} 
+Release:        %{planex_release}
 Summary:        Low-level xen control operations OCaml
 License:        LGPL
 Group:          Development/Other

--- a/ocaml-xenstore-clients.spec.in
+++ b/ocaml-xenstore-clients.spec.in
@@ -1,6 +1,9 @@
+%define planex_version 0.0.0
+%define planex_release 1
+
 Name:           ocaml-xenstore-clients
-Version:        @VERSION@
-Release:        0
+Version:        %{planex_version}
+Release:        %{planex_release}
 Summary:        Unix xenstore clients for OCaml
 License:        LGPL
 Group:          Development/Other

--- a/ocaml-xenstore.spec.in
+++ b/ocaml-xenstore.spec.in
@@ -1,6 +1,9 @@
+%define planex_version 0.0.0
+%define planex_release 1
+
 Name:           ocaml-xenstore
-Version:        @VERSION@
-Release:        0
+Version:        %{planex_version}
+Release:        %{planex_release}
 Summary:        Xenstore protocol implementation in OCaml
 License:        LGPL
 Group:          Development/Other

--- a/sm-cli.spec.in
+++ b/sm-cli.spec.in
@@ -1,6 +1,9 @@
+%define planex_version 0.0.0
+%define planex_release 1
+
 Name:           sm-cli
-Version:        0.9.3
-Release:        1
+Version:        %{planex_version}
+Release:        %{planex_release}
 Summary:        CLI for xapi toolstack storage managers.
 License:        LGPL
 Group:          Development/Other

--- a/squeezed.spec.in
+++ b/squeezed.spec.in
@@ -1,6 +1,9 @@
+%define planex_version 0.0.0
+%define planex_release 1
+
 Name:           squeezed
-Version:        @VERSION@
-Release:        1
+Version:        %{planex_version}
+Release:        %{planex_release}
 Summary:        Memory ballooning daemon for the xapi toolstack
 License:        LGPL
 Group:          Development/Other

--- a/vhd-tool.spec.in
+++ b/vhd-tool.spec.in
@@ -1,8 +1,11 @@
+%define planex_version 0.0.0
+%define planex_release 1
+
 # -*- rpm-spec -*-
 
 Name:           vhd-tool
-Version:        @VERSION@
-Release:        1
+Version:        %{planex_version}
+Release:        %{planex_release}
 Summary:        command-line tools for manipulating and streaming .vhd format files
 License:        LGPL+linking exception
 Group:          System/Hypervisor

--- a/vhdd.spec.in
+++ b/vhdd.spec.in
@@ -1,6 +1,9 @@
+%define planex_version 0.0.0
+%define planex_release 1
+
 Name:           vhdd
-Version:        @VERSION@
-Release:        1
+Version:        %{planex_version}
+Release:        %{planex_release}
 Summary:        A VHD management SMAPI daemon
 License:        LGPL
 Group:          Development/Other

--- a/xcp-networkd.spec.in
+++ b/xcp-networkd.spec.in
@@ -1,6 +1,9 @@
+%define planex_version 0.0.0
+%define planex_release 1
+
 Name:           xcp-networkd
-Version:        @VERSION@
-Release:        1
+Version:        %{planex_version}
+Release:        %{planex_release}
 Summary:        Simple host network management service for the xapi toolstack
 License:        LGPL
 Group:          Development/Other

--- a/xcp-rrdd.spec.in
+++ b/xcp-rrdd.spec.in
@@ -1,6 +1,9 @@
+%define planex_version 0.0.0
+%define planex_release 1
+
 Name: xcp-rrdd
-Version: @VERSION@
-Release: 1
+Version: %{planex_version}
+Release: %{planex_release}
 Summary: Statistics gathering daemon for the xapi toolstack
 License: LGPL
 Group: Development/Other

--- a/xenops-cli.spec.in
+++ b/xenops-cli.spec.in
@@ -1,6 +1,9 @@
+%define planex_version 0.0.0
+%define planex_release 1
+
 Name:           xenops-cli
-Version:        @VERSION@
-Release:        2
+Version:        %{planex_version}
+Release:        %{planex_release}
 Summary:        CLI for xenopsd, the xapi toolstack domain manager
 License:        LGPL
 Group:          Development/Other

--- a/xenopsd.spec.in
+++ b/xenopsd.spec.in
@@ -1,6 +1,9 @@
+%define planex_version 0.0.0
+%define planex_release 1
+
 Name:           xenopsd
-Version:        @VERSION@
-Release:        1
+Version:        %{planex_version}
+Release:        %{planex_release}
 Summary:        Simple VM manager
 License:        LGPL
 Group:          Development/Other


### PR DESCRIPTION
Define `planex_version` and `planex_release`, needed by the new version of planex.   It will replace these definitions, rather than rewriting the @VERSION@ tag.
