### PR TITLE
xen-api-libs-specs uses the old cmdliner name (should be ocaml-cmdliner-...

### DIFF
--- a/ocaml-nbd.spec
+++ b/ocaml-nbd.spec
@@ -8,7 +8,7 @@ Source0:        https://github.com/xapi-project/nbd/archive/v%{version}/nbd-%{ve
 
 BuildRequires:  ocaml
 BuildRequires:  ocaml-camlp4-devel
-BuildRequires:  ocaml-cmdliner-devel
+BuildRequires:  cmdliner-devel
 BuildRequires:  ocaml-cstruct-devel
 BuildRequires:  ocaml-findlib-devel
 BuildRequires:  ocaml-lwt-devel


### PR DESCRIPTION
...)

Signed-off-by: David Scott dave.scott@eu.citrix.com
