### PR TITLE
CA-141955: Use new search path feature from xcp-idl

### DIFF
--- a/SOURCES/xenopsd-64-conf
+++ b/SOURCES/xenopsd-64-conf
@@ -1,5 +1,7 @@
 # Configuration file for xenopsd
 
+search-path=/usr/lib64/xen/bin:/usr/libexec/xenopsd:/usr/lib/xen/boot
+
 # Number of threads which will service the VM operation queues
 worker-pool-size=16
 
@@ -9,26 +11,17 @@ disable-logging-for=http
 # We don't run the hotplug scripts ourself until the netback is fixed (breaks windows PV drivers)
 run_hotplug_scripts=false
 
-xenguest=/usr/lib64/xen/bin/xenguest
-
 network-conf=/etc/xensource/network.conf
 
-vif-script=/usr/libexec/xenopsd/vif
-vif-xl-script=/usr/libexec/xenopsd/vif-xl
-qemu-vif-script=/usr/libexec/xenopsd/qemu-vif-script
-qemu-dm-wrapper=/usr/libexec/xenopsd/qemu-dm-wrapper
-setup-vif-rules=/usr/libexec/xenopsd/setup-vif-rules
-vgpu=/usr/lib64/xen/bin/vgpu
-vbd-script=/usr/libexec/xenopsd/block
-vbd-xl-script=/usr/libexec/xenopsd/block-xl
+vif-script=vif
+vif-xl-script=vif-xl
+vbd-script=block
+vbd-xl-script=block-xl
 qemu-system-i386=/bin/false
 
-
-hvmloader=/usr/lib/xen/boot/hvmloader
 pygrub=/usr/bin/pygrub
 sockets-group=wheel
 
-vncterm=/usr/lib64/xen/bin/vncterm
 eliloader=/usr/bin/eliloader
 
 use-switch=false

--- a/SOURCES/xenopsd-conf
+++ b/SOURCES/xenopsd-conf
@@ -1,5 +1,7 @@
 # Configuration file for xenopsd
 
+search-path=/usr/lib/xen/bin:/usr/libexec/xenopsd:/usr/lib/xen/boot
+
 # Number of threads which will service the VM operation queues
 worker-pool-size=16
 
@@ -9,26 +11,17 @@ disable-logging-for=http
 # We don't run the hotplug scripts ourself until the netback is fixed (breaks windows PV drivers)
 run_hotplug_scripts=false
 
-xenguest=/usr/lib/xen/bin/xenguest
-
 network-conf=/etc/xensource/network.conf
 
-vif-script=/usr/libexec/xenopsd/vif
-vif-xl-script=/usr/libexec/xenopsd/vif-xl
-qemu-vif-script=/usr/libexec/xenopsd/qemu-vif-script
-qemu-dm-wrapper=/usr/libexec/xenopsd/qemu-dm-wrapper
-setup-vif-rules=/usr/libexec/xenopsd/setup-vif-rules
-vgpu=/usr/lib/xen/bin/vgpu
-vbd-script=/usr/libexec/xenopsd/block
-vbd-xl-script=/usr/libexec/xenopsd/block-xl
+vif-script=vif
+vif-xl-script=vif-xl
+vbd-script=block
+vbd-xl-script=block-xl
 qemu-system-i386=/bin/false
 
-
-hvmloader=/usr/lib/xen/boot/hvmloader
 pygrub=/usr/bin/pygrub
 sockets-group=wheel
 
-vncterm=/usr/lib/xen/bin/vncterm
 eliloader=/usr/bin/eliloader
 
 use-switch=false


### PR DESCRIPTION
Now we can specify a search path in xenopsd.conf we no longer need to hardcode
all the paths to the binaries we need. Some are still needed where the basename
differs from what is expected but many can disappear.

Signed-off-by: Si Beaumont simon.beaumont@citrix.com
