### PR TITLE
ocaml-xen-lowlevel-libs: don't even try to build xenguest

### DIFF
--- a/ocaml-xen-lowlevel-libs.spec.in
+++ b/ocaml-xen-lowlevel-libs.spec.in
@@ -31,7 +31,7 @@ developing applications that use %{name}.
 
 %build
 make configure
-./configure --disable-xenctrl
+./configure --disable-xenctrl --disable-xenguest
 make build
 
 %install


### PR DESCRIPTION
We have xenguest binaries for xen-4.2 and xen-4.4. Unfortunately
trunk seems to be neither of those (looking at the API)

Signed-off-by: David Scott dave.scott@eu.citrix.com
