### PR TITLE
More removal of Requires where the XS build system is poorly factored.

### DIFF
--- a/ocaml-xcp-idl.spec.in
+++ b/ocaml-xcp-idl.spec.in
@@ -11,7 +11,7 @@ Summary:        Common interface definitions for XCP services
 License:        LGPL
 URL:            https://github.com/xapi-project/xcp-idl
 Source0:        git://github.com/xapi-project/xcp-idl
-
+Patch0:         xcp-idl-dont-use-switch
 BuildRequires:  ocaml
 BuildRequires:  ocaml-camlp4-devel
 BuildRequires:  ocaml-cmdliner-devel
@@ -48,6 +48,7 @@ developing applications that use %{name}.
 
 %prep
 %setup -q -n xcp-idl-%{version}
+%patch1 -p1
 
 %build
 ocaml setup.ml -configure

--- a/xenopsd.spec.in
+++ b/xenopsd.spec.in
@@ -41,7 +41,7 @@ BuildRequires:  ocaml-xcp-rrd-devel
 Requires:       message-switch
 #Requires:       redhat-lsb-core
 Requires:       xenops-cli
-Requires:       vncterm
+#Requires:       vncterm
 #Requires:       linux-guest-loader
 Requires:       ocaml-xen-lowlevel-libs-runtime
 
@@ -61,7 +61,7 @@ Simple VM manager for the xapi toolstack.
 Summary:        Xenopsd using xc
 Requires:       %{name} = %{version}-%{release}
 Requires:       forkexecd
-Requires:       vncterm
+#Requires:       vncterm
 Requires:       xen-libs
 
 %description    xc


### PR DESCRIPTION
Also reinstitute the patch in xcp-idl to disable the message switch

Signed-off-by: Jon Ludlam jonathan.ludlam@citrix.com
