### PR TITLE
Networkd depends upon libnl3

### DIFF
--- a/xcp-networkd.spec.in
+++ b/xcp-networkd.spec.in
@@ -26,6 +26,7 @@ BuildRequires:  ocaml-xen-api-client-devel
 BuildRequires:  ocaml-netlink-devel
 BuildRequires:  libffi-devel
 Requires:       ethtool
+Requires:       libnl3
 #Requires:       redhat-lsb-core
 
 %description


### PR DESCRIPTION
Signed-off-by: Jon Ludlam jonathan.ludlam@citrix.com
