### PR TITLE
XS has config files in /etc/xensource, not /etc/xcp

### DIFF
--- a/xcp-networkd.spec.in
+++ b/xcp-networkd.spec.in
@@ -49,7 +49,7 @@ make install DESTDIR=%{buildroot} BINDIR=%{_bindir} SBINDIR=%{_sbindir}
 mkdir -p %{buildroot}%{_sysconfdir}/init.d
 install -m 0755 xcp-networkd-init %{buildroot}%{_sysconfdir}/init.d/xcp-networkd
 mkdir -p %{buildroot}/etc/xcp
-install -m 0644 xcp-networkd-network-conf %{buildroot}/etc/xcp/network.conf
+install -m 0644 xcp-networkd-network-conf %{buildroot}/etc/xensource/network.conf
 install -m 0644 xcp-networkd-conf %{buildroot}/etc/xcp-networkd.conf
 mkdir -p %{buildroot}/etc/modprobe.d
 #install -m 0644 xcp-networkd-bridge-conf %{buildroot}/etc/modprobe.d/bridge.conf
@@ -60,7 +60,7 @@ mkdir -p %{buildroot}/etc/modprobe.d
 %{_bindir}/networkd_db
 %{_sysconfdir}/init.d/xcp-networkd
 #/etc/modprobe.d/bridge.conf
-%config(noreplace) /etc/xcp/network.conf
+%config(noreplace) /etc/xensource/network.conf
 %config(noreplace) /etc/xcp-networkd.conf
 
 %post


### PR DESCRIPTION
Signed-off-by: Jon Ludlam jonathan.ludlam@citrix.com
