### PR TITLE
CP-9987: Add blktap-devel as a dependency to xcp-rrdd

### DIFF
--- a/xcp-rrdd.spec.in
+++ b/xcp-rrdd.spec.in
@@ -26,6 +26,7 @@ BuildRequires:  forkexecd-devel
 BuildRequires:  xen-devel
 BuildRequires:  xen-dom0-libs-devel
 BuildRequires:  xen-libs-devel
+BuildRequires:  blktap-devel
 #Requires:       redhat-lsb-core
 
 %description


### PR DESCRIPTION
As part of the blktap3 stats changes, make xcp-rrdd build depend on the
blktap-devel RPM which contains the required headers.

Signed-off-by: Siddharth Vinothkumar siddharth.vinothkumar@citrix.com
