### PR TITLE
Require python-devel so that .py files are byte-compiled

### DIFF
--- a/xenopsd.spec.in
+++ b/xenopsd.spec.in
@@ -38,6 +38,7 @@ BuildRequires:  xen-libs-devel
 BuildRequires:  xen-dom0-libs-devel
 BuildRequires:  ocaml-uutf-devel
 BuildRequires:  ocaml-xcp-rrd-devel
+BuildRequires:  python-devel
 Requires:       message-switch
 #Requires:       redhat-lsb-core
 Requires:       xenops-cli


### PR DESCRIPTION
Without this, *.pyc and *.pyo files are not included in the RPM like
they should be.

Signed-off-by: Ross Lagerwall <ross.lagerwall@citrix.com>