### PR TITLE
Speed up builds

### DIFF
--- a/mock/default.cfg
+++ b/mock/default.cfg
@@ -3,6 +3,7 @@ config_opts['target_arch'] = 'x86_64'
 config_opts['root'] = 'dom0'
 config_opts['legal_host_arches'] = ('x86_64',)
 config_opts['chroot_setup_cmd'] = 'install bash bzip2 coreutils cpio diffutils findutils gawk gcc gcc-c++ grep gzip info make patch redhat-rpm-config rpm-build sed shadow-utils tar unzip util-linux-ng which xz'
+config_opts['chroot_setup_cmd'] += ' blktap-devel device-mapper-devel forkexecd-devel libffi-devel libuuid-devel ocaml ocaml-camldm-devel ocaml-camlp4-devel ocaml-camlzip-devel ocaml-cmdliner-devel ocaml-cohttp-devel ocaml-crc-devel ocaml-cstruct-devel ocaml-fd-send-recv-devel ocaml-findlib ocaml-findlib-devel ocaml-io-page-devel ocaml-lwt-devel ocaml-mlvm-devel ocaml-nbd-devel ocaml-netdev-devel ocaml-netlink-devel ocaml-obuild ocaml-ocamldoc ocaml-oclock-devel ocaml-ounit-devel ocaml-qmp-devel ocaml-re-devel ocaml-rpc-devel ocaml-sexplib-devel ocaml-sha-devel ocaml-stdext-devel ocaml-tapctl-devel ocaml-tar-devel ocaml-uuidm-devel ocaml-uutf-devel ocaml-vhd-devel ocaml-xmlm-devel python-devel xen-devel xen-dom0-libs xen-dom0-libs-devel xen-libs xen-libs-devel xen-ocaml-devel'
 config_opts['dist'] = 'el6'  # only useful for --resultdir variable subst
 config_opts['plugin_conf']['bind_mount_opts']['dirs'].append(('/output', '/output' ))
 config_opts['plugin_conf']['bind_mount_opts']['dirs'].append(('/var/xen-mock', '/var/xen-mock'))


### PR DESCRIPTION
Improve build speed by:
1) Excluding various bind mounted directories that balloon up the size
of root_cache.tar.gz to a few gigabytes which then means all the build
time is spent on disk IO. (the root cache went from 2.4GB to 155MB)

2) Include a bunch of commonly required dependencies in the root cache
to reduce the time spent running yum-builddep for each mock call.

Signed-off-by: Ross Lagerwall <ross.lagerwall@citrix.com>