### PR TITLE
xcp-rrdd depends on oclock

### DIFF
--- a/xcp-rrdd.spec.in
+++ b/xcp-rrdd.spec.in
@@ -14,6 +14,7 @@ BuildRequires:  ocaml
 BuildRequires:  ocaml-camlp4-devel
 BuildRequires:  ocaml-findlib
 BuildRequires:  ocaml-obuild
+BuildRequires:  ocaml-oclock-devel
 BuildRequires:  ocaml-rpc-devel
 BuildRequires:  ocaml-xcp-idl-devel
 BuildRequires:  ocaml-xcp-inventory-devel


### PR DESCRIPTION
This was masked by the message-switch bringing it in transitively.
Now the message-switch is using mtime, this nolonger happens.

Signed-off-by: David Scott <dave.scott@citrix.com>