### PR TITLE
CP-12902: change the command-line to be more consistent

### DIFF
--- a/SOURCES/xcp-rrdd-init
+++ b/SOURCES/xcp-rrdd-init
@@ -50,7 +50,7 @@ start() {
 	# Enable core dumps
 	ulimit -c unlimited
 
-	${CMD} -pidfile ${PID_FILE} -daemon true $XCP_RRDD_OPTIONS >/dev/null 2>&1 </dev/null
+	${CMD} --pidfile ${PID_FILE} --daemon true $XCP_RRDD_OPTIONS >/dev/null 2>&1 </dev/null
 
 	MAX_RETRIES=30
 	RETRY=0


### PR DESCRIPTION
xcp-rrdd 655ee6959a36930fc9a0b80bfeda922e69c6978f uses the new
`Xcp_service.configure2` API which means that

-pidfile <FOO>    ==>  --pidfile <FOO>
-daemon true      ==>  --daemon true

Signed-off-by: David Scott <dave.scott@eu.citrix.com>

Needs to be merged as the same time as [xapi-project/xcp-rrdd#52]