### PR TITLE
vhd-tool: `make install` requires config.mk to exist

### DIFF
--- a/SPECS/vhd-tool.spec
+++ b/SPECS/vhd-tool.spec
@@ -39,6 +39,7 @@ make
 mkdir -p %{buildroot}/%{_bindir}
 mkdir -p %{buildroot}/%{_libexecdir}/xapi
 mkdir -p %{buildroot}/etc
+./configure --bindir %{buildroot}/%{_bindir} --libexecdir %{buildroot}/%{_libexecdir}/xapi --etcdir %{buildroot}/etc
 make install
 
 


### PR DESCRIPTION
Signed-off-by: David Scott <dave.scott@eu.citrix.com>