### PR TITLE
xenopsd: specify the inventory file path in the config file

### DIFF
--- a/SOURCES/xenopsd-64-conf
+++ b/SOURCES/xenopsd-64-conf
@@ -1,5 +1,7 @@
 # Configuration file for xenopsd
 
+inventory=/etc/xensource-inventory
+
 search-path=/usr/libexec/xen/bin:/usr/libexec/xen/boot:/usr/lib64/xen/bin:/usr/libexec/xenopsd:/usr/lib/xen/boot
 
 # Number of threads which will service the VM operation queues

--- a/SOURCES/xenopsd-conf
+++ b/SOURCES/xenopsd-conf
@@ -1,5 +1,7 @@
 # Configuration file for xenopsd
 
+inventory=/etc/xensource-inventory
+
 search-path=/usr/lib/xen/bin:/usr/libexec/xenopsd:/usr/lib/xen/boot
 
 # Number of threads which will service the VM operation queues


### PR DESCRIPTION
If a developer builds a xenopsd binary by hand then it might look for
the inventory file in the wrong place.

Signed-off-by: David Scott <dave.scott@citrix.com>

Conflicts:
	SOURCES/xenopsd-conf