### PR TITLE
Start xcp-networkd with priority 14

### DIFF
--- a/SOURCES/xcp-networkd-init
+++ b/SOURCES/xcp-networkd-init
@@ -2,7 +2,7 @@
 #
 # xcp-networkd     Start/Stop the XCP networking daemon
 #
-# chkconfig: 2345 13 76
+# chkconfig: 2345 14 76
 # description: XCP networking daemon
 # processname: xcp-networkd
 # pidfile: /var/run/xcp-networkd.pid

--- a/SOURCES/xcp-networkd-init.upstream
+++ b/SOURCES/xcp-networkd-init.upstream
@@ -2,7 +2,7 @@
 #
 #  xcp-networkd        Startup script for network management service
 #
-# chkconfig: 2345 13 88
+# chkconfig: 2345 14 88
 # description: Manages host networking for VMs.
 ### BEGIN INIT INFO
 # Provides: xcp-networkd


### PR DESCRIPTION
This ensures that xcp-networkd is started after forkexecd, which has a start
priority of 13 (since 97cc4745 in forkexecd.git).

(Also see xapi-project/xcp-networkd#58)