### PR TITLE
mock: Always delete mock chroots after build, regardless of outcome

### DIFF
--- a/mock/site-defaults.cfg
+++ b/mock/site-defaults.cfg
@@ -43,8 +43,8 @@ config_opts['cache_topdir'] = '/home/xenbuild/mock/cache'
 # mock build directory, but only take effect if --resultdir is used.
 # config_opts provides fine-grained control. cmdline only has big hammer
 #
-config_opts['cleanup_on_success'] = False
-config_opts['cleanup_on_failure'] = False
+# config_opts['cleanup_on_success'] = True
+# config_opts['cleanup_on_failure'] = True
 
 # if you want mock to automatically run createrepo on the rpms in your
 # resultdir.


### PR DESCRIPTION
 * Keeping chroots after successful builds has little value and
   increases the risk that future builds will fail because of
   insufficient disk space.

 * Keeping chroots after failed builds can help with debugging
   build failures.   However if a failure is systematic, it should be
   possible to reproduce it in another run.  If necessary, the build
   can be run by hand in the chroot using `mock --shell`.   Keeping
   the failed chroot in all cases just increases the chance of
   running out of disk space, causing more infrastructure-related
   build failures.

Signed-off-by: Euan Harris <euan.harris@citrix.com>