### PR TITLE
Startup sequence: start xenopsd and squeezed before attach-static-vdis

### DIFF
--- a/SOURCES/squeezed-init
+++ b/SOURCES/squeezed-init
@@ -2,7 +2,7 @@
 #
 #  squeeze        Startup script for memory ballooning daemon
 #
-# chkconfig: 2345 22 88
+# chkconfig: 2345 19 88
 # description: Manages host memory by ballooning VMs
 
 # Source function library.

--- a/SOURCES/xenopsd-xc-init
+++ b/SOURCES/xenopsd-xc-init
@@ -2,7 +2,7 @@
 #
 #  xenopsd-xc        Startup script for xenopsd-xc service
 #
-# chkconfig: 2345 22 88
+# chkconfig: 2345 19 88
 # description: Manages xen domains via libxc
 
 # Source function library.

--- a/SOURCES/xenopsd-xenlight-init
+++ b/SOURCES/xenopsd-xenlight-init
@@ -2,7 +2,7 @@
 #
 #  xenopsd-xenlight        Startup script for xenopsd-xenlight service
 #
-# chkconfig: 2345 22 88
+# chkconfig: 2345 19 88
 # description: Manages VMs via libxl
 
 # Source function library.


### PR DESCRIPTION
This is safe since slot 19 was unused before this, attach-static-vdis is at slot 20, and the only thing in between 19 and 22 (what these were) is v6d which has no dependency relation with xenopsd or squeezed.

Signed-off-by: Si Beaumont <simon.beaumont@citrix.com>