### PR TITLE
xenopsd: add ocaml-bisect-ppx dependency for coverage analysis

### DIFF
--- a/SPECS/xenopsd.spec
+++ b/SPECS/xenopsd.spec
@@ -37,7 +37,7 @@ BuildRequires:  xen-dom0-libs-devel
 BuildRequires:  ocaml-uutf-devel
 BuildRequires:  ocaml-xcp-rrd-devel
 BuildRequires:  python-devel
-BuildRequires:  ocaml-bisect-ppx
+BuildRequires:  ocaml-bisect-ppx-devel
 Requires:       message-switch
 #Requires:       redhat-lsb-core
 Requires:       xenops-cli

--- a/SPECS/xenopsd.spec
+++ b/SPECS/xenopsd.spec
@@ -37,6 +37,7 @@ BuildRequires:  xen-dom0-libs-devel
 BuildRequires:  ocaml-uutf-devel
 BuildRequires:  ocaml-xcp-rrd-devel
 BuildRequires:  python-devel
+BuildRequires:  ocaml-bisect-ppx
 Requires:       message-switch
 #Requires:       redhat-lsb-core
 Requires:       xenops-cli


### PR DESCRIPTION
This new dependency is required to build `xenopsd` with profiling. It should not do any harm if we build for the regular case.

Signed-off-by: Christian Lindig <christian.lindig@citrix.com>