### PR TITLE
Add ocaml-bisect-ppx-devel as build dep for various pkgs to enable coverage profiling

### DIFF
--- a/SPECS/ocaml-xenstore-clients.spec
+++ b/SPECS/ocaml-xenstore-clients.spec
@@ -14,6 +14,7 @@ BuildRequires:  ocaml-findlib
 BuildRequires:  ocaml-lwt-devel
 BuildRequires:  ocaml-xenstore-devel
 BuildRequires:  ocaml-ounit-devel
+BuildRequires:  ocaml-bisect-ppx-devel
 
 %description
 Unix xenstore clients for OCaml.

--- a/SPECS/squeezed.spec
+++ b/SPECS/squeezed.spec
@@ -22,6 +22,7 @@ BuildRequires:  xen-dom0-libs-devel
 BuildRequires:  xen-dom0-libs
 BuildRequires:  xen-libs-devel
 BuildRequires:  xen-libs
+BuildRequires:  ocaml-bisect-ppx-devel
 #Requires:       redhat-lsb-core
 Requires:       message-switch
 

--- a/SPECS/vhd-tool.spec
+++ b/SPECS/vhd-tool.spec
@@ -21,6 +21,7 @@ BuildRequires: ocaml-io-page-devel
 BuildRequires: ocaml-sha-devel
 BuildRequires: ocaml-tar-devel
 BuildRequires: ocaml-xenstore-clients-devel
+BuildRequires: ocaml-bisect-ppx-devel
 
 %description
 Simple command-line tools for manipulating and streaming .vhd format file.

--- a/SPECS/xcp-networkd.spec
+++ b/SPECS/xcp-networkd.spec
@@ -22,6 +22,7 @@ BuildRequires:  ocaml-xcp-inventory-devel
 BuildRequires:  ocaml-xen-api-client-devel
 BuildRequires:  ocaml-netlink-devel
 BuildRequires:  libffi-devel
+BuildRequires:  ocaml-bisect-ppx-devel
 Requires:       ethtool
 Requires:       libnl3
 #Requires:       redhat-lsb-core

--- a/SPECS/xcp-rrdd.spec
+++ b/SPECS/xcp-rrdd.spec
@@ -25,6 +25,7 @@ BuildRequires:  xen-devel
 BuildRequires:  xen-dom0-libs-devel
 BuildRequires:  xen-libs-devel
 BuildRequires:  blktap-devel
+BuildRequires:  ocaml-bisect-ppx-devel
 #Requires:       redhat-lsb-core
 
 %description


### PR DESCRIPTION
This dependency is only needed when we compile for coverage profiling
but does no harm otherwise.

Signed-off-by: Christian Lindig <christian.lindig@citrix.com>