### PR TITLE
xenopsd: introduce sub package for coverage analysis

### DIFF
--- a/SPECS/xcp-networkd.spec
+++ b/SPECS/xcp-networkd.spec
@@ -1,6 +1,6 @@
 Name:           xcp-networkd
-Version:        0.10.1
-Release:        1%{?dist}
+Version:        0.9.6
+Release:        2%{?dist}
 Summary:        Simple host network management service for the xapi toolstack
 License:        LGPL
 URL:            https://github.com/xapi-project/xcp-networkd
@@ -42,38 +42,24 @@ cp %{SOURCE3} xcp-networkd-network-conf
 #cp %{SOURCE4} xcp-networkd-bridge-conf
 
 %build
-mkdir root1 root2
 make
-make install DESTDIR=$PWD/root1 BINDIR=%{_bindir} SBINDIR=%{_sbindir}
-
-make clean
-make coverage
-make
-make install DESTDIR=$PWD/root2 BINDIR=%{_bindir} SBINDIR=%{_sbindir}
 
 %install
-rsync -a $PWD/root2/ %{buildroot}
-# rename
-mv    %{buildroot}%{_sbindir}/xcp-networkd %{buildroot}%{_sbindir}/xcp-networkd.cov
-mv    %{buildroot}%{_bindir}/networkd_db   %{buildroot}%{_bindir}/networkd_db.cov
-
-rsync -a $PWD/root1/ %{buildroot}
-mv    %{buildroot}%{_sbindir}/xcp-networkd %{buildroot}%{_sbindir}/xcp-networkd.bin
-mv    %{buildroot}%{_bindir}/networkd_db   %{buildroot}%{_bindir}/networkd_db.bin
-
-touch %{buildroot}%{_sbindir}/xcp-networkd
-touch %{buildroot}%{_bindir}/networkd_db
-install -D -m 0755 xcp-networkd-init %{buildroot}%{_sysconfdir}/init.d/xcp-networkd
-install -D -m 0644 xcp-networkd-network-conf %{buildroot}/etc/xensource/network.conf
-install -D -m 0644 xcp-networkd-conf %{buildroot}/etc/xcp-networkd.conf
-
+mkdir -p %{buildroot}/%{_sbindir}
+mkdir -p %{buildroot}/%{_bindir}
+make install DESTDIR=%{buildroot} BINDIR=%{_bindir} SBINDIR=%{_sbindir}
+mkdir -p %{buildroot}%{_sysconfdir}/init.d
+install -m 0755 xcp-networkd-init %{buildroot}%{_sysconfdir}/init.d/xcp-networkd
+mkdir -p %{buildroot}/etc/xensource
+install -m 0644 xcp-networkd-network-conf %{buildroot}/etc/xensource/network.conf
+install -m 0644 xcp-networkd-conf %{buildroot}/etc/xcp-networkd.conf
+mkdir -p %{buildroot}/etc/modprobe.d
+#install -m 0644 xcp-networkd-bridge-conf %{buildroot}/etc/modprobe.d/bridge.conf
 
 %files
 %doc README.markdown LICENSE MAINTAINERS
-%ghost %{_sbindir}/xcp-networkd
-%ghost %{_bindir}/networkd_db
-%{_sbindir}/xcp-networkd.bin
-%{_bindir}/networkd_db.bin
+%{_sbindir}/xcp-networkd
+%{_bindir}/networkd_db
 %{_sysconfdir}/init.d/xcp-networkd
 %{_mandir}/man1/xcp-networkd.1.gz
 #/etc/modprobe.d/bridge.conf
@@ -83,15 +69,9 @@ install -D -m 0644 xcp-networkd-conf %{buildroot}/etc/xcp-networkd.conf
 %post
 case $1 in
   1) # install
-    ln -s %{_sbindir}/xcp-networkd.bin  %{_sbindir}/xcp-networkd
-    ln -s %{_bindir}/networkd_db.bin    %{_bindir}/networkd_db
     /sbin/chkconfig --add xcp-networkd
     ;;
   2) # upgrade
-    rm -f %{_sbindir}/xcp-networkd
-    rm -f %{_bindir}/networkd_db
-    ln -s %{_sbindir}/xcp-networkd.bin  %{_sbindir}/xcp-networkd
-    ln -s %{_bindir}/networkd_db.bin    %{_bindir}/networkd_db
     /sbin/chkconfig --del xcp-networkd
     /sbin/chkconfig --add xcp-networkd
     ;;
@@ -107,42 +87,7 @@ case $1 in
     ;;
 esac
 
-%package coverage
-Summary: Simple host network management service for the xapi toolstack:
-Requires:       %{name} = %{version}-%{release}
-
-%description coverage
-This package enables coverage profiling.
-
-%files coverage
-%ghost %{_sbindir}/xcp-networkd
-%ghost %{_bindir}/networkd_db
-%{_sbindir}/xcp-networkd.cov
-%{_bindir}/networkd_db.cov
-
-%post coverage
-case $1 in
-  1) # install
-    ln -s %{_sbindir}/xcp-networkd.cov  %{_sbindir}/xcp-networkd
-    ln -s %{_bindir}/networkd_db.cov    %{_bindir}/networkd_db
-    /sbin/chkconfig --add xcp-networkd
-    ;;
-  2) # upgrade
-    rm -f %{_sbindir}/xcp-networkd
-    rm -f %{_bindir}/networkd_db
-    ln -s %{_sbindir}/xcp-networkd.cov  %{_sbindir}/xcp-networkd
-    ln -s %{_bindir}/networkd_db.cov    %{_bindir}/networkd_db
-    /sbin/chkconfig --del xcp-networkd
-    /sbin/chkconfig --add xcp-networkd
-    ;;
-esac
-
-
 %changelog
-* Fri May 20 2016 Christian Lindig <christian.lindig@citrix.com>
-- New upstream release that supports coverage profiling
-- introduce sub package for coverage profiling
-
 * Mon May 16 2016 Si Beaumont <simon.beaumont@citrix.com> - 0.9.6-2
 - Re-run chkconfig on upgrade
 
@@ -166,4 +111,3 @@ esac
 * Wed Jun  5 2013 David Scott <dave.scott@eu.citrix.com>
 - Initial package
 
-# vim: set ts=2 sw=2 et:

--- a/SPECS/xenopsd.spec
+++ b/SPECS/xenopsd.spec
@@ -310,7 +310,7 @@ esac
 
 
 %changelog
-* Fri May 20 2016 Christian Lindig <christian.lindig@citrix.com> - * 0.12.1-1
+* Fri May 20 2016 Christian Lindig <christian.lindig@citrix.com> - 0.12.1-1
 - New upstream release that supports coverage analysis
 - Introduce subpackages *-cov for coverage analysis
 

--- a/SPECS/xenopsd.spec
+++ b/SPECS/xenopsd.spec
@@ -1,6 +1,6 @@
 Name:           xenopsd
-Version:        0.12.0
-Release:        2%{?dist}
+Version:        0.12.1
+Release:        1%{?dist}
 Summary:        Simple VM manager
 License:        LGPL
 URL:            https://github.com/xapi-project/xenopsd
@@ -23,8 +23,6 @@ BuildRequires:  ocaml-cohttp-devel
 BuildRequires:  forkexecd-devel
 BuildRequires:  ocaml-oclock-devel
 BuildRequires:  ocaml-uuidm-devel
-#BuildRequires:  libvirt-devel
-#BuildRequires:  ocaml-libvirt-devel
 BuildRequires:  ocaml-qmp-devel
 BuildRequires:  ocaml-sexplib-devel
 BuildRequires:  xen-ocaml-devel
@@ -39,10 +37,7 @@ BuildRequires:  ocaml-xcp-rrd-devel
 BuildRequires:  python-devel
 BuildRequires:  ocaml-bisect-ppx-devel
 Requires:       message-switch
-#Requires:       redhat-lsb-core
 Requires:       xenops-cli
-#Requires:       vncterm
-#Requires:       linux-guest-loader
 Requires:       xen-dom0-tools
 
 Requires(post): /sbin/chkconfig
@@ -51,14 +46,6 @@ Requires(preun): /sbin/service
 
 %description
 Simple VM manager for the xapi toolstack.
-
-#%package        libvirt
-#Summary:        Xenopsd using libvirt
-#Requires:       %{name} = %{version}-%{release}
-#Requires:       libvirt
-
-#%description    libvirt
-#Simple VM manager for Xen and KVM using libvirt.
 
 %package        xc
 Summary:        Xenopsd using xc
@@ -70,6 +57,18 @@ Requires:       xen-libs
 %description    xc
 Simple VM manager for Xen using libxc.
 
+%package        xc-cov
+Summary:        Xenopsd using xc
+Requires:       %{name} = %{version}-%{release}
+Requires:       forkexecd
+#Requires:       vncterm
+Requires:       xen-libs
+
+%description    xc-cov
+Simple VM manager for Xen using libxc with coverage
+profiling.
+
+
 %package        simulator
 Summary:        Xenopsd simulator
 Requires:       %{name} = %{version}-%{release}
@@ -77,15 +76,34 @@ Requires:       %{name} = %{version}-%{release}
 %description    simulator
 A synthetic VM manager for testing.
 
+%package        simulator-cov
+Summary:        Xenopsd simulator
+Requires:       %{name} = %{version}-%{release}
+
+%description    simulator-cov
+A synthetic VM manager for testing with coverage profiling.
+
+
+
 %package        xenlight
 Summary:        Xenopsd using libxenlight
 Group:          Development/Other
 Requires:       %{name} = %{version}-%{release}
+
 %description    xenlight
 Simple VM manager for Xen using libxenlight
 
-%prep
-%setup -q
+%package        xenlight-cov
+Summary:        Xenopsd using libxenlight
+Group:          Development/Other
+Requires:       %{name} = %{version}-%{release}
+
+%description    xenlight-cov
+Simple VM manager for Xen using libxenlight with coverage profiling.
+
+
+%prep 
+%setup -q 
 cp %{SOURCE1} xenopsd-xc-init
 cp %{SOURCE2} xenopsd-simulator-init
 cp %{SOURCE3} xenopsd-libvirt-init
@@ -95,20 +113,54 @@ cp %{SOURCE6} xenopsd-network-conf
 cp %{SOURCE7} xenopsd-64-conf
 
 %build
+# this is a hack: we build and install two builds into the source
+# directory under root1 and root2. In the install step all we do is
+# copying files from it.
+
+mkdir root1 root2
 ./configure --libexecdir %{_libexecdir}/%{name}
+
+# regular build
 make
+make install DESTDIR=$PWD/root1 LIBEXECDIR=%{_libexecdir}/%{name} SBINDIR=%{_sbindir} MANDIR=%{_mandir} 
+make clean
+
+# now build for coverage profiling
+make coverage
+make
+make install DESTDIR=$PWD/root2 LIBEXECDIR=%{_libexecdir}/%{name} SBINDIR=%{_sbindir} MANDIR=%{_mandir} 
 
 %install
-make install DESTDIR=%{buildroot} LIBEXECDIR=%{_libexecdir}/%{name} SBINDIR=%{_sbindir} MANDIR=%{_mandir} 
+# this installs the files from the first build
+rsync -a root1/ %{buildroot} 
 
+# rename regular binaries
+mv %{buildroot}%{_sbindir}/xenopsd-xc                     %{buildroot}%{_sbindir}/xenopsd-xc.bin
+mv %{buildroot}%{_libexecdir}/%{name}/set-domain-uuid     %{buildroot}%{_libexecdir}/%{name}/set-domain-uuid.bin
+# mv %{buildroot}%{_sbindir}/xenopsd-xenlight       %{buildroot}%{_sbindir}/xenopsd-xenlight.bin 
+# mv %{buildroot}%{_sbindir}/xenopsd-simulator      %{buildroot}%{_sbindir}/xenopsd-simulator.bin
+
+# install selected binaries with coverage profiling from second build
+install -D ./xenops_xc_main.native        %{buildroot}%{_sbindir}/xenopsd-xc.cov
+install -D ./set_domain_uuid.native       %{buildroot}%{_libexecdir}/%{name}/set-domain-uuid.cov
+# install -D ./xenops_xl_main.native        %{buildroot}%{_sbindir}/xenopsd-xenlight.cov
+# install -D ./xenops_simulator_main.native %{buildroot}%{_sbindir}/xenopsd-simulator.cov
+
+touch %{buildroot}%{_sbindir}/xenopsd-xenlight
+touch %{buildroot}%{_sbindir}/xenopsd-simulator
+touch %{buildroot}%{_sbindir}/xenopsd-xc
+touch %{buildroot}%{_libexecdir}/%{name}/set-domain-uuid
+
+
+# this is the same for both builds - should really be in Makefile
 gzip %{buildroot}%{_mandir}/man1/*.1
 
-install -D -m 0755 xenopsd-xenlight-init %{buildroot}/%{_sysconfdir}/init.d/xenopsd-xenlight
-install -m 0755 xenopsd-xc-init %{buildroot}/%{_sysconfdir}/init.d/xenopsd-xc
-install -m 0755 xenopsd-simulator-init %{buildroot}/%{_sysconfdir}/init.d/xenopsd-simulator
-mkdir -p %{buildroot}/etc/xapi
-install -m 0644 xenopsd-64-conf %{buildroot}/etc/xenopsd.conf
-install -m 0644 xenopsd-network-conf %{buildroot}/etc/xapi/network.conf
+install -D -m 0755 xenopsd-xenlight-init  %{buildroot}%{_sysconfdir}/init.d/xenopsd-xenlight
+install    -m 0755 xenopsd-xc-init        %{buildroot}%{_sysconfdir}/init.d/xenopsd-xc
+install    -m 0755 xenopsd-simulator-init %{buildroot}%{_sysconfdir}/init.d/xenopsd-simulator
+mkdir -p                                  %{buildroot}/etc/xapi
+install    -m 0644 xenopsd-64-conf        %{buildroot}/etc/xenopsd.conf
+install    -m 0644 xenopsd-network-conf   %{buildroot}/etc/xapi/network.conf
 
 %files
 %doc README.md LICENSE
@@ -126,43 +178,30 @@ install -m 0644 xenopsd-network-conf %{buildroot}/etc/xapi/network.conf
 /etc/xapi/network.conf
 /etc/udev/rules.d/xen-backend.rules
 
-#%files libvirt
-#%{_sbindir}/xenopsd-libvirt
-#%{_sysconfdir}/init.d/xenopsd-libvirt
-#
-#%post libvirt
-#case $1 in
-#  1) # install
-#    /sbin/chkconfig --add xenopsd-libvirt
-#    ;;
-#  2) # upgrade
-#    /sbin/chkconfig --del xenopsd-libvirt
-#    /sbin/chkconfig --add xenopsd-libvirt
-#    ;;
-#esac
-#
-#%preun libvirt
-#case $1 in
-#  0) # uninstall
-#    /sbin/service xenopsd-libvirt stop >/dev/null 2>&1 || :
-#    /sbin/chkconfig --del xenopsd-libvirt
-#    ;;
-#  1) # upgrade
-#    ;;
-#esac
+# ---
 
 %files xc
-%{_sbindir}/xenopsd-xc
+%{_sbindir}/xenopsd-xc.bin
+%ghost %{_sbindir}/xenopsd-xc
 %{_sysconfdir}/init.d/xenopsd-xc
 %{_mandir}/man1/xenopsd-xc.1.gz
-%{_libexecdir}/%{name}/set-domain-uuid
+%{_libexecdir}/%{name}/set-domain-uuid.bin
+%ghost %{_libexecdir}/%{name}/set-domain-uuid
+
 
 %post xc
 case $1 in
   1) # install
+    ln -s %{_sbindir}/xenopsd-xc.bin %{_sbindir}/xenopsd-xc
+    ln -s %{_libexecdir}/%{name}/set-domain-uuid.bin %{_libexecdir}/%{name}/set-domain-uuid
     /sbin/chkconfig --add xenopsd-xc
     ;;
   2) # upgrade
+    rm -f %{_sbindir}/xenopsd-xc
+    ln -s %{_sbindir}/xenopsd-xc.bin %{_sbindir}/xenopsd-xc
+    rm -f %{_libexecdir}/%{name}/set-domain-uuid
+    ln -s %{_libexecdir}/%{name}/set-domain-uuid.bin %{_libexecdir}/%{name}/set-domain-uuid
+    
     /sbin/chkconfig --del xenopsd-xc
     /sbin/chkconfig --add xenopsd-xc
     ;;
@@ -177,6 +216,43 @@ case $1 in
   1) # upgrade
     ;;
 esac
+
+%files xc-cov
+%{_sbindir}/xenopsd-xc.cov
+%{_sysconfdir}/init.d/xenopsd-xc
+%{_mandir}/man1/xenopsd-xc.1.gz
+%{_libexecdir}/%{name}/set-domain-uuid.cov
+%ghost %{_sbindir}/xenopsd-xc
+
+%post xc-cov
+case $1 in
+  1) # install
+    ln -s %{_sbindir}/xenopsd-xc.cov %{_sbindir}/xenopsd-xc
+    ln -s %{_libexecdir}/%{name}/set-domain-uuid.cov %{_libexecdir}/%{name}/set-domain-uuid
+    /sbin/chkconfig --add xenopsd-xc
+    ;;
+  2) # upgrade
+    rm -f %{_sbindir}/xenopsd-xc
+    ln -s %{_sbindir}/xenopsd-xc.cov %{_sbindir}/xenopsd-xc
+    rm -f %{_libexecdir}/%{name}/set-domain-uuid
+    ln -s %{_libexecdir}/%{name}/set-domain-uuid.cov %{_libexecdir}/%{name}/set-domain-uuid
+    /sbin/chkconfig --del xenopsd-xc
+    /sbin/chkconfig --add xenopsd-xc
+    ;;
+esac
+
+%preun xc-cov
+case $1 in
+  0) # uninstall
+    /sbin/service xenopsd-xc stop >/dev/null 2>&1 || :
+    /sbin/chkconfig --del xenopsd-xc
+    ;;
+  1) # upgrade
+    ;;
+esac
+
+
+# -- simulator
 
 %files simulator
 %{_sbindir}/xenopsd-simulator
@@ -203,6 +279,9 @@ case $1 in
   1) # upgrade
     ;;
 esac
+
+
+# --- xenlight
 
 %files xenlight
 %defattr(-,root,root)
@@ -231,7 +310,13 @@ case $1 in
     ;;
 esac
 
+
 %changelog
+* Fri May 20 2016 Christian Lindig <christian.lindig@citrix.com> 
+- 0.12.1
+- New upstream release that supports coverage analysis
+- Introduce subpacke *-cov for coverage analysis
+
 * Mon May 16 2016 Si Beaumont <simon.beaumont@citrix.com> - 0.12.0-2
 - Re-run chkconfig on upgrade
 

--- a/SPECS/xenopsd.spec
+++ b/SPECS/xenopsd.spec
@@ -36,6 +36,7 @@ BuildRequires:  ocaml-uutf-devel
 BuildRequires:  ocaml-xcp-rrd-devel
 BuildRequires:  python-devel
 BuildRequires:  ocaml-bisect-ppx-devel
+BuildRequires:  rsync
 Requires:       message-switch
 Requires:       xenops-cli
 Requires:       xen-dom0-tools
@@ -413,3 +414,5 @@ esac
 
 * Thu May 30 2013 David Scott <dave.scott@eu.citrix.com>
 - Initial package
+
+# vim: set ts=2 sw=2 et:


### PR DESCRIPTION
This introduces  a sub package xc-cov with binaries that write coverage data to `/tmp`. The spec file depends on a new upstream release for this. Packaging relies on symlinks that pick the normal or instrumented binary.