### PR TITLE
xenopsd: CP-17268 fix %post for xc-cov, rm existing symlink first

### DIFF
--- a/SPECS/xenopsd.spec
+++ b/SPECS/xenopsd.spec
@@ -1,6 +1,6 @@
 Name:           xenopsd
 Version:        0.12.1
-Release:        1%{?dist}
+Release:        2%{?dist}
 Summary:        Simple VM manager
 License:        LGPL
 URL:            https://github.com/xapi-project/xenopsd
@@ -225,7 +225,9 @@ esac
 %post xc-cov
 case $1 in
   1) # install
+    rm -f %{_sbindir}/xenopsd-xc
     ln -s %{_sbindir}/xenopsd-xc.cov %{_sbindir}/xenopsd-xc
+    rm -f %{_libexecdir}/%{name}/set-domain-uuid
     ln -s %{_libexecdir}/%{name}/set-domain-uuid.cov %{_libexecdir}/%{name}/set-domain-uuid
     /sbin/chkconfig --add xenopsd-xc
     ;;
@@ -310,6 +312,9 @@ esac
 
 
 %changelog
+* Thu May 26 2016 Christian Lindig <christian.lindig@citrix.com> - 0.12.1-2
+- Fix %post xc-cov: have to rm existing symlink just like in upgrade
+
 * Fri May 20 2016 Christian Lindig <christian.lindig@citrix.com> - 0.12.1-1
 - New upstream release that supports coverage analysis
 - Introduce subpackages *-cov for coverage analysis

--- a/SPECS/xenopsd.spec
+++ b/SPECS/xenopsd.spec
@@ -100,8 +100,8 @@ Requires:       %{name} = %{version}-%{release}
 Simple VM manager for Xen using libxenlight with coverage profiling.
 
 
-%prep 
-%setup -q 
+%prep
+%setup -q
 cp %{SOURCE1} xenopsd-xc-init
 cp %{SOURCE2} xenopsd-simulator-init
 cp %{SOURCE3} xenopsd-libvirt-init
@@ -120,13 +120,13 @@ mkdir build-bin build-cov
 
 # regular build
 make
-make install DESTDIR=$PWD/build-bin LIBEXECDIR=%{_libexecdir}/%{name} SBINDIR=%{_sbindir} MANDIR=%{_mandir} 
+make install DESTDIR=$PWD/build-bin LIBEXECDIR=%{_libexecdir}/%{name} SBINDIR=%{_sbindir} MANDIR=%{_mandir}
 make clean
 
 # now build for coverage profiling
 make coverage
 make
-make install DESTDIR=$PWD/build-cov LIBEXECDIR=%{_libexecdir}/%{name} SBINDIR=%{_sbindir} MANDIR=%{_mandir} 
+make install DESTDIR=$PWD/build-cov LIBEXECDIR=%{_libexecdir}/%{name} SBINDIR=%{_sbindir} MANDIR=%{_mandir}
 
 %install
 # this installs the files from the bin build
@@ -135,7 +135,7 @@ make install DESTDIR=$PWD/build-cov LIBEXECDIR=%{_libexecdir}/%{name} SBINDIR=%{
 # rename regular binaries
 mv %{buildroot}%{_sbindir}/xenopsd-xc                     %{buildroot}%{_sbindir}/xenopsd-xc.bin
 mv %{buildroot}%{_libexecdir}/%{name}/set-domain-uuid     %{buildroot}%{_libexecdir}/%{name}/set-domain-uuid.bin
-# mv %{buildroot}%{_sbindir}/xenopsd-xenlight       %{buildroot}%{_sbindir}/xenopsd-xenlight.bin 
+# mv %{buildroot}%{_sbindir}/xenopsd-xenlight       %{buildroot}%{_sbindir}/xenopsd-xenlight.bin
 # mv %{buildroot}%{_sbindir}/xenopsd-simulator      %{buildroot}%{_sbindir}/xenopsd-simulator.bin
 
 # install selected binaries with coverage profiling from coverage build
@@ -190,16 +190,14 @@ install    -m 0644 xenopsd-network-conf   %{buildroot}/etc/xapi/network.conf
 %post xc
 case $1 in
   1) # install
-    ln -s %{_sbindir}/xenopsd-xc.bin %{_sbindir}/xenopsd-xc
-    ln -s %{_libexecdir}/%{name}/set-domain-uuid.bin %{_libexecdir}/%{name}/set-domain-uuid
+    ln -fs %{_sbindir}/xenopsd-xc.bin %{_sbindir}/xenopsd-xc
+    ln -fs %{_libexecdir}/%{name}/set-domain-uuid.bin %{_libexecdir}/%{name}/set-domain-uuid
     /sbin/chkconfig --add xenopsd-xc
     ;;
   2) # upgrade
-    rm -f %{_sbindir}/xenopsd-xc
-    ln -s %{_sbindir}/xenopsd-xc.bin %{_sbindir}/xenopsd-xc
-    rm -f %{_libexecdir}/%{name}/set-domain-uuid
-    ln -s %{_libexecdir}/%{name}/set-domain-uuid.bin %{_libexecdir}/%{name}/set-domain-uuid
-    
+    ln -fs %{_sbindir}/xenopsd-xc.bin %{_sbindir}/xenopsd-xc
+    ln -fs %{_libexecdir}/%{name}/set-domain-uuid.bin %{_libexecdir}/%{name}/set-domain-uuid
+
     /sbin/chkconfig --del xenopsd-xc
     /sbin/chkconfig --add xenopsd-xc
     ;;
@@ -225,17 +223,13 @@ esac
 %post xc-cov
 case $1 in
   1) # install
-    rm -f %{_sbindir}/xenopsd-xc
-    ln -s %{_sbindir}/xenopsd-xc.cov %{_sbindir}/xenopsd-xc
-    rm -f %{_libexecdir}/%{name}/set-domain-uuid
-    ln -s %{_libexecdir}/%{name}/set-domain-uuid.cov %{_libexecdir}/%{name}/set-domain-uuid
+    ln -fs %{_sbindir}/xenopsd-xc.cov %{_sbindir}/xenopsd-xc
+    ln -fs %{_libexecdir}/%{name}/set-domain-uuid.cov %{_libexecdir}/%{name}/set-domain-uuid
     /sbin/chkconfig --add xenopsd-xc
     ;;
   2) # upgrade
-    rm -f %{_sbindir}/xenopsd-xc
-    ln -s %{_sbindir}/xenopsd-xc.cov %{_sbindir}/xenopsd-xc
-    rm -f %{_libexecdir}/%{name}/set-domain-uuid
-    ln -s %{_libexecdir}/%{name}/set-domain-uuid.cov %{_libexecdir}/%{name}/set-domain-uuid
+    ln -fs %{_sbindir}/xenopsd-xc.cov %{_sbindir}/xenopsd-xc
+    ln -fs %{_libexecdir}/%{name}/set-domain-uuid.cov %{_libexecdir}/%{name}/set-domain-uuid
     /sbin/chkconfig --del xenopsd-xc
     /sbin/chkconfig --add xenopsd-xc
     ;;
@@ -370,7 +364,7 @@ esac
 - Update to 0.9.37
 
 * Fri Jan 17 2014 Euan Harris <euan.harris@eu.citrix.com> - 0.9.34-1
-- Update to 0.9.34, restoring fixes from the 0.9.32 line which were 
+- Update to 0.9.34, restoring fixes from the 0.9.32 line which were
   not merged to trunk before 0.9.33 was tagged
 
 * Wed Dec 4 2013 Euan Harris <euan.harris@eu.citrix.com> - 0.9.33-1


### PR DESCRIPTION
This fixes a packaging problem that was revealed when I installed `xenopsd-xc-cov`.

`xenopsd-xc-cov` can be installed without uninstaling `xenopsd-xc` first (which I had originally assumed). This means that the sym link `xenopsd-xc` can already exist and needs to be removed before installing a
new one.

Signed-off-by: Christian Lindig <christian.lindig@citrix.com>