### PR TITLE
xenopsd: Remove definition of xenlight-cov subpackage, which is never…

### DIFF
--- a/SPECS/xenopsd.spec
+++ b/SPECS/xenopsd.spec
@@ -91,15 +91,6 @@ Requires:       %{name} = %{version}-%{release}
 %description    xenlight
 Simple VM manager for Xen using libxenlight
 
-%package        xenlight-cov
-Summary:        Xenopsd using libxenlight
-Group:          Development/Other
-Requires:       %{name} = %{version}-%{release}
-
-%description    xenlight-cov
-Simple VM manager for Xen using libxenlight with coverage profiling.
-
-
 %prep
 %setup -q
 cp %{SOURCE1} xenopsd-xc-init


### PR DESCRIPTION
… built

This package had no %files section, so no RPM was produced.
It happened to be the last package defined in the spec file so make,
based on the deps file produced by planex-depend, was checking for
xenopsd-xenlight-cov, never finding it and therefore continually
rebuliding xenopsd.

Signed-off-by: Euan Harris <euan.harris@citrix.com>