### PR TITLE
xcp-networkd: Fix unpinned build

### DIFF
--- a/SPECS/squeezed.spec
+++ b/SPECS/squeezed.spec
@@ -1,6 +1,6 @@
 Name:           squeezed
-Version:        0.11.0
-Release:        2%{?dist}
+Version:        0.12.1
+Release:        1%{?dist}
 Summary:        Memory ballooning daemon for the xapi toolstack
 License:        LGPL
 URL:            https://github.com/xapi-project/squeezed
@@ -78,6 +78,9 @@ case $1 in
 esac
 
 %changelog
+* Fri Jul 22 2016 Jon Ludlam <jonathan.ludlam@citrix.com> - 0.12.1-1
+- New release
+
 * Mon May 16 2016 Si Beaumont <simon.beaumont@citrix.com> - 0.11.0-2
 - Re-run chkconfig on upgrade
 

--- a/SPECS/xcp-networkd.spec
+++ b/SPECS/xcp-networkd.spec
@@ -1,5 +1,5 @@
 Name:           xcp-networkd
-Version:        0.11.0
+Version:        0.11.1
 Release:        1%{?dist}
 Summary:        Simple host network management service for the xapi toolstack
 License:        LGPL
@@ -87,6 +87,9 @@ case $1 in
 esac
 
 %changelog
+* Fri Jul 22 2016 Jon Ludlam <jonathan.ludlam@citrix.com> - 0.11.1-1
+- Update to 0.11.1
+
 * Mon Jun 27 2016 Euan Harris <euan.harris@citrix.com> - 0.11.0-1
 - Update to 0.11.0
 

--- a/SPECS/xcp-rrdd.spec
+++ b/SPECS/xcp-rrdd.spec
@@ -1,6 +1,6 @@
 Name:           xcp-rrdd
-Version:        1.0.0
-Release:        2%{?dist}
+Version:        1.0.1
+Release:        1%{?dist}
 Summary:        Statistics gathering daemon for the xapi toolstack
 License:        LGPL
 URL:            https://github.com/xapi-project/xcp-rrdd
@@ -78,6 +78,9 @@ case $1 in
 esac
 
 %changelog
+* Mon Jul 25 2016 Jon Ludlam <jonathan.ludlam@citrix.com> - 1.0.1-1
+- Update to 1.0.1
+
 * Mon May 16 2016 Si Beaumont <simon.beaumont@citrix.com> - 1.0.0-2
 - Re-run chkconfig on upgrade
 

--- a/SPECS/xenopsd.spec
+++ b/SPECS/xenopsd.spec
@@ -300,6 +300,12 @@ esac
 * Fri Aug 12 2016 Christian Lindig <christian.lindig@citrix.com> - 0.13.0-1
 - Version bump; xenopsd maintains state for nested_virt, nomigrate
 
+* Thu Aug 18 2016 Jon Ludlam <jonathan.ludlam@citrix.com> - 0.12.3-1
+- New release
+
+* Fri Jul 22 2016 Jon Ludlam <jonathan.ludlam@citrix.com> - 0.12.2-1
+- New release
+
 * Thu May 26 2016 Christian Lindig <christian.lindig@citrix.com> - 0.12.1-2
 - Fix %post xc-cov: have to rm existing symlink just like in upgrade
 


### PR DESCRIPTION
xcp-networkd usually tracks master.  These changes update the 
spec file to the latest release and make it build correctly.