### PR TITLE
ffs, xapi-storage-datapath-plugins: BuildRequire python-devel

### DIFF
--- a/SPECS/ffs.spec
+++ b/SPECS/ffs.spec
@@ -5,6 +5,7 @@ Summary:        Simple flat file storage manager for the xapi toolstack
 License:        LGPL
 URL:            https://github.com/xapi-project/ffs
 Source0:        https://github.com/xapi-project/%{name}/archive/v%{version}/%{name}-%{version}.tar.gz
+BuildRequires:  python-devel
 Requires:       xapi-storage
 Requires:       xapi-storage-datapath-plugins
 Requires:       btrfs-progs
@@ -18,7 +19,7 @@ Simple flat file storage manager for the xapi toolstack.
 %build
 
 %install
-DESTDIR=%{buildroot} SCRIPTDIR=%{_libexecdir}/xapi-storage-script/ PYTHONDIR=/usr/lib/python2.7/site-packages/xapi/storage/ffs make install
+DESTDIR=%{buildroot} SCRIPTDIR=%{_libexecdir}/xapi-storage-script/ PYTHONDIR=%{python_sitelib}/xapi/storage/ffs make install
 
 %files
 %doc README.md LICENSE MAINTAINERS

--- a/SPECS/xapi-storage-datapath-plugins.spec
+++ b/SPECS/xapi-storage-datapath-plugins.spec
@@ -5,6 +5,7 @@ Summary:        Storage datapath plugins for the xapi toolstack
 License:        LGPL
 URL:            https://github.com/xapi-project/xapi-storage-datapath-plugins
 Source0:        https://github.com/xapi-project/%{name}/archive/v%{version}/%{name}-%{version}.tar.gz
+BuildRequires:  python-devel
 Requires:       xapi-storage
 
 %description
@@ -16,7 +17,7 @@ Storage datapath plugins for the xapi toolstack.
 %build
 
 %install
-DESTDIR=%{buildroot} SCRIPTDIR=%{_libexecdir}/xapi-storage-script/ PYTHONDIR=/usr/lib/python2.7/site-packages/xapi/storage/datapath make install
+DESTDIR=%{buildroot} SCRIPTDIR=%{_libexecdir}/xapi-storage-script/ PYTHONDIR=%{python_sitelib}/xapi/storage/datapath make install
 
 %files
 %doc README.md LICENSE


### PR DESCRIPTION
This causes the %python_sitelib macro to work, and also
causes the Python files to be byte-compiled in the binary
package.

Signed-off-by: Euan Harris <euan.harris@citrix.com>