### PR TITLE
CP18720: Switch from %setup to %autosetup

### DIFF
--- a/SPECS/ezlvm.spec
+++ b/SPECS/ezlvm.spec
@@ -35,7 +35,7 @@ Requires: xapi-storage-datapath-plugins
 Simple LVM storage adapter for xapi
 
 %prep 
-%setup -q -n %{name}-%{version}
+%autosetup -n %{name}-%{version}
 
 %build
 cd src

--- a/SPECS/ffs.spec
+++ b/SPECS/ffs.spec
@@ -14,7 +14,7 @@ Requires:       btrfs-progs
 Simple flat file storage manager for the xapi toolstack.
 
 %prep
-%setup -q
+%autosetup
 
 %build
 

--- a/SPECS/forkexecd.spec
+++ b/SPECS/forkexecd.spec
@@ -26,7 +26,7 @@ A service which starts and manages subprocesses, avoiding the need to manually
 fork() and exec() in a multithreaded program.
 
 %prep
-%setup -q
+%autosetup
 
 %build
 ocaml setup.ml -configure

--- a/SPECS/message-switch.spec
+++ b/SPECS/message-switch.spec
@@ -34,7 +34,7 @@ Requires(preun): /sbin/service
 A store and forward message switch for OCaml.
 
 %prep
-%setup -q
+%autosetup
 cp %{SOURCE1} message-switch-init
 cp %{SOURCE2} message-switch-conf
 cp %{SOURCE3} message-switch.xml

--- a/SPECS/ocaml-gnt.spec
+++ b/SPECS/ocaml-gnt.spec
@@ -38,7 +38,7 @@ The %{name}-devel package contains libraries and signature files for
 developing applications that use %{name}.
 
 %prep
-%setup -q
+%autosetup
 
 %build
 make

--- a/SPECS/ocaml-libvhd.spec
+++ b/SPECS/ocaml-libvhd.spec
@@ -28,7 +28,7 @@ The %{name}-devel package contains libraries and signature files for
 developing applications that use %{name}.
 
 %prep
-%setup -q -n libvhd-%{version}
+%autosetup -n libvhd-%{version}
 
 %build
 ocaml setup.ml -configure

--- a/SPECS/ocaml-netdev.spec
+++ b/SPECS/ocaml-netdev.spec
@@ -27,7 +27,7 @@ The %{name}-devel package contains libraries and signature files for
 developing applications that use %{name}.
 
 %prep
-%setup -q -n netdev-%{version}
+%autosetup -n netdev-%{version}
 
 %build
 oasis setup

--- a/SPECS/ocaml-rrd-transport.spec
+++ b/SPECS/ocaml-rrd-transport.spec
@@ -33,7 +33,7 @@ The %{name}-devel package contains libraries and signature files for
 developing applications that use %{name}.
 
 %prep
-%setup -q -n rrd-transport-%{version}
+%autosetup -n rrd-transport-%{version}
 
 %build
 ocaml setup.ml -configure --libdir %{buildroot}%{_libdir}/ocaml

--- a/SPECS/ocaml-rrdd-plugin.spec
+++ b/SPECS/ocaml-rrdd-plugin.spec
@@ -37,7 +37,7 @@ The %{name}-devel package contains libraries and signature files for
 developing applications that use %{name}.
 
 %prep
-%setup -q
+%autosetup
 
 %build
 make

--- a/SPECS/ocaml-tapctl.spec
+++ b/SPECS/ocaml-tapctl.spec
@@ -30,7 +30,7 @@ The %{name}-devel package contains libraries and signature files for
 developing applications that use %{name}.
 
 %prep
-%setup -q -n tapctl-%{version}
+%autosetup -n tapctl-%{version}
 
 %build
 oasis setup

--- a/SPECS/ocaml-xcp-idl.spec
+++ b/SPECS/ocaml-xcp-idl.spec
@@ -44,7 +44,7 @@ The %{name}-devel package contains libraries and signature files for
 developing applications that use %{name}.
 
 %prep
-%setup -q -n xcp-idl-%{version}
+%autosetup -n xcp-idl-%{version}
 
 %build
 ocaml setup.ml -configure

--- a/SPECS/ocaml-xcp-inventory.spec
+++ b/SPECS/ocaml-xcp-inventory.spec
@@ -29,7 +29,7 @@ The %{name}-devel package contains libraries and signature files for
 developing applications that use %{name}.
 
 %prep
-%setup -q -n xcp-inventory-%{version}
+%autosetup -n xcp-inventory-%{version}
 
 %build
 oasis setup

--- a/SPECS/ocaml-xcp-rrd.spec
+++ b/SPECS/ocaml-xcp-rrd.spec
@@ -29,7 +29,7 @@ The %{name}-devel package contains libraries and signature files for
 developing applications that use %{name}.
 
 %prep
-%setup -q -n xcp-rrd-%{version}
+%autosetup -n xcp-rrd-%{version}
 
 %build
 make

--- a/SPECS/ocaml-xen-api-client.spec
+++ b/SPECS/ocaml-xen-api-client.spec
@@ -42,7 +42,7 @@ It is used for programmatically controlling a pool of XenServer
 virtualization hosts.
 
 %prep
-%setup -q -n xen-api-client-%{version}
+%autosetup -n xen-api-client-%{version}
 
 %build
 make

--- a/SPECS/ocaml-xen-api-libs-transitional.spec
+++ b/SPECS/ocaml-xen-api-libs-transitional.spec
@@ -37,7 +37,7 @@ The %{name}-devel package contains libraries and signature files for
 developing applications that use %{name}.
 
 %prep
-%setup -q -n xen-api-libs-transitional-%{version}
+%autosetup -n xen-api-libs-transitional-%{version}
 
 %build
 make

--- a/SPECS/ocaml-xenops.spec
+++ b/SPECS/ocaml-xenops.spec
@@ -46,7 +46,7 @@ BuildRequires:  xen-devel
 A set of debugging tools which showcase the features of %{name}-devel.
 
 %prep
-%setup -q -n xenops-%{version}
+%autosetup -n xenops-%{version}
 
 %build
 make

--- a/SPECS/ocaml-xenstore-clients.spec
+++ b/SPECS/ocaml-xenstore-clients.spec
@@ -30,7 +30,7 @@ The %{name}-devel package contains libraries and signature files for
 developing applications that use %{name}.
 
 %prep
-%setup -q
+%autosetup
 
 %build
 make CONFIGUREFLAGS=--bindir=%{buildroot}/%{_libexecdir}

--- a/SPECS/sm-cli.spec
+++ b/SPECS/sm-cli.spec
@@ -17,7 +17,7 @@ BuildRequires:  ocaml-xcp-idl-devel
 Command-line interface for xapi toolstack storage managers.
 
 %prep
-%setup -q
+%autosetup
 
 %build
 make

--- a/SPECS/squeezed.spec
+++ b/SPECS/squeezed.spec
@@ -33,7 +33,7 @@ Requires:       message-switch
 Memory ballooning daemon for the xapi toolstack.
 
 %prep
-%setup -q
+%autosetup
 
 %build
 ./configure --prefix %{_prefix} --destdir %{buildroot}

--- a/SPECS/vhd-tool.spec
+++ b/SPECS/vhd-tool.spec
@@ -28,7 +28,7 @@ BuildRequires: ocaml-bisect-ppx-devel
 Simple command-line tools for manipulating and streaming .vhd format file.
 
 %prep 
-%setup -q
+%autosetup
 cp %{SOURCE1} vhd-tool-sparse_dd-conf
 
 

--- a/SPECS/xapi-storage-datapath-plugins.spec
+++ b/SPECS/xapi-storage-datapath-plugins.spec
@@ -12,7 +12,7 @@ Requires:       xapi-storage
 Storage datapath plugins for the xapi toolstack.
 
 %prep
-%setup -q
+%autosetup
 
 %build
 

--- a/SPECS/xapi-storage.spec
+++ b/SPECS/xapi-storage.spec
@@ -40,8 +40,7 @@ The %{name}-devel package contains libraries and signature files for
 developing applications that use %{name}.
 
 %prep
-%setup -q -n %{name}-%{version}
-%patch0 -p1
+%autosetup -n %{name}-%{version}
 
 %build
 make

--- a/SPECS/xapi-test-utils.spec
+++ b/SPECS/xapi-test-utils.spec
@@ -23,7 +23,7 @@ The %{name}-devel package contains libraries and signature files for
 developing applications that use %{name}.
 
 %prep
-%setup -q
+%autosetup
 
 %build
 make

--- a/SPECS/xcp-networkd.spec
+++ b/SPECS/xcp-networkd.spec
@@ -34,7 +34,7 @@ Requires:       libnl3
 Simple host networking management service for the xapi toolstack.
 
 %prep
-%setup -q
+%autosetup
 
 %build
 make

--- a/SPECS/xcp-rrdd.spec
+++ b/SPECS/xcp-rrdd.spec
@@ -36,7 +36,7 @@ BuildRequires:  ocaml-systemd-devel
 Statistics gathering daemon for the xapi toolstack.
 
 %prep
-%setup -q
+%autosetup
 
 %build
 make

--- a/SPECS/xenops-cli.spec
+++ b/SPECS/xenops-cli.spec
@@ -17,7 +17,7 @@ BuildRequires:  oasis
 Command-line interface for xenopsd, the xapi toolstack domain manager.
 
 %prep
-%setup -q
+%autosetup
 
 %build
 make

--- a/SPECS/xenopsd.spec
+++ b/SPECS/xenopsd.spec
@@ -93,7 +93,7 @@ Simple VM manager for Xen using libxenlight with coverage profiling.
 
 
 %prep
-%setup -q
+%autosetup
 
 %build
 # this is a hack: we build and install two builds into the source


### PR DESCRIPTION
%autosetup is now the recommended way to unpack sources
and apply patches automatically.  This makes pinning and
linking in Planex much easier.

Signed-off-by: Euan Harris <euan.harris@citrix.com>