### PR TITLE
xcp-rrd: create group rrdmetrics, create /dev/shm/metrics at startup CP-19068

### DIFF
--- a/SOURCES/xcp-rrdd-tmp
+++ b/SOURCES/xcp-rrdd-tmp
@@ -1,0 +1,1 @@
+d /dev/shm/metrics 0775 root rrdmetrics -


### PR DESCRIPTION
The behaviour of xcp-rrd changes slightly: upon startup it creates
/dev/shm/metrics with rrdmetrics as a group. This gives rrd plugins a
chance to write to this directory without root credentials. The group is
created during installation.

I have tested that the RPM builds but have not yet tested that the directory is created by the tmpdir.d service at runtime.

Signed-off-by: Christian Lindig <christian.lindig@citrix.com>