### PR TITLE
xcp-networkd: update to 0.13.3

### DIFF
--- a/SPECS/xcp-networkd.spec
+++ b/SPECS/xcp-networkd.spec
@@ -1,10 +1,10 @@
 Name:           xcp-networkd
-Version:        0.13.2
+Version:        0.13.3
 Release:        1%{?dist}
 Summary:        Simple host network management service for the xapi toolstack
 License:        LGPL
 URL:            https://github.com/xapi-project/xcp-networkd
-Source0:        https://github.com/xapi-project/xcp-networkd/archive/v%{version}/xcp-networkd-%{version}.tar.gz
+Source0:        https://github.com/xenserver/xcp-networkd/archive/v%{version}/xcp-networkd-%{version}.tar.gz
 Source1:        xcp-networkd.service
 Source2:        xcp-networkd-sysconfig
 Source3:        xcp-networkd-conf
@@ -68,6 +68,9 @@ make install DESTDIR=%{buildroot} BINDIR=%{_bindir} SBINDIR=%{_sbindir}
 %systemd_postun_with_restart xcp-networkd.service
 
 %changelog
+* Tue Dec 06 2016 Gabor Igloi <gabor.igloi@citrix.com> - 0.13.3-1
+- CA-234506: Don't lose the port `kind` param in bridge.make_config
+
 * Fri Nov 04 2016 Euan Harris <euan.harris@citrix.com> - 0.13.2-1
 - CA-225272: rate-limit calls to `ovs-vsctl`
 


### PR DESCRIPTION
Do the additional step explained in https://github.com/xenserver/xen-api-libs-specs/commit/407cc835957d067ed2f5ed33ce1877c363e7107c:
Update the SPEC file to exactly match the one in xenserver-specs.

Signed-off-by: Gabor Igloi <gabor.igloi@citrix.com>