### PR TITLE
Update xcp-networkd and xenopsd

### DIFF
--- a/SPECS/xcp-networkd.spec
+++ b/SPECS/xcp-networkd.spec
@@ -1,5 +1,5 @@
 Name:           xcp-networkd
-Version:        0.13.2
+Version:        0.13.3
 Release:        1%{?dist}
 Summary:        Simple host network management service for the xapi toolstack
 License:        LGPL
@@ -68,6 +68,9 @@ make install DESTDIR=%{buildroot} BINDIR=%{_bindir} SBINDIR=%{_sbindir}
 %systemd_postun_with_restart xcp-networkd.service
 
 %changelog
+* Tue Dec 06 2016 Gabor Igloi <gabor.igloi@citrix.com> - 0.13.3-1
+- CA-234506: Don't lose the port `kind` param in bridge.make_config
+
 * Fri Nov 04 2016 Euan Harris <euan.harris@citrix.com> - 0.13.2-1
 - CA-225272: rate-limit calls to `ovs-vsctl`
 

--- a/SPECS/xenopsd.spec
+++ b/SPECS/xenopsd.spec
@@ -1,6 +1,6 @@
 Name:           xenopsd
-Version:        0.17.0
-Release:        2%{?dist}
+Version:        0.20.0
+Release:        1%{?dist}
 Summary:        Simple VM manager
 License:        LGPL
 URL:            https://github.com/xapi-project/xenopsd
@@ -241,6 +241,15 @@ esac
 %systemd_postun_with_restart xenopsd-xenlight.service
 
 %changelog
+* Wed Dec 07 2016 Gabor Igloi <gabor.igloi@citrix.com> - 0.20.0-1
+- CA-227605: Fix issues with PVS caching under stress tests
+- CA-226099: Revert previous fix; ensure that disabled VIFs are not put on a bridge
+- vif-real: log with a consistent tag
+- CA-227626: Look for VIF in all the pvs-proxy sites
+- CA-227101: Increase timeout from 0 to 60 seconds when squeezing domains.
+- CP-19645: qemu-dm-wrapper: Allow QEMU to be optionally used when starting a guest
+- CA-220466: bootloader: check kernel/ramdisk paths
+
 * Mon Nov 21 2016 Rob Hoes <rob.hoes@citrix.com> - 0.17.0-2
 - Install systemd service files with 644 permissions (non-executable)
 


### PR DESCRIPTION
Update the version of `xcp-networkd`, which hasn't diverged, to match the [`ely-bugfix`](https://github.com/xenserver/xcp-networkd/tree/ely-bugfix) version, and release `xenopsd` `v0.20.0`, which has diverged from [its `ely-bugfix` version](https://github.com/xenserver/xenopsd/tree/ely-bugfix).

Most of the changes between xenopsd `v0.20.0` and `v0.17.0` are also in its [`ely-bugfix`](https://github.com/xenserver/xenopsd/tree/ely-bugfix) branch, but I had to create an completely separate changelog which lists again the common changes that happened since the two versions diverged (it lists the `ely-bugfix` changes between `v0.17.0` and `v0.17.5`), due to the linear nature of git.