### PR TITLE
CA-244698: Use new ocaml-vhd with backported fix for CA-218219

### DIFF
--- a/SPECS/vhd-tool.spec
+++ b/SPECS/vhd-tool.spec
@@ -2,7 +2,7 @@
 Summary: Command-line tools for manipulating and streaming .vhd format files
 Name:    vhd-tool
 Version: 0.8.0
-Release: 3%{?dist}
+Release: 4%{?dist}
 License: LGPL+linking exception
 URL:  https://github.com/xapi-project/vhd-tool
 Source0: https://github.com/xapi-project/vhd-tool/archive/v%{version}/vhd-tool-%{version}.tar.gz
@@ -52,6 +52,9 @@ install -m 755 get_vhd_vsize.native %{buildroot}/%{_libexecdir}/xapi/get_vhd_vsi
 %{_libexecdir}/xapi/get_vhd_vsize
 
 %changelog
+* Thu Mar 23 2017 Frederico Mazzone <frederico.mazzone@citrix.com> - 0.8.0-4
+- Use ocaml-vhd-v0.7.3-5 - Fixes CA-244698 by backporting fix for CA-218219
+
 * Fri Jun 24 2016 Christian Lindig <christian.lindig@citrix.com> 0.8.0-3
 - This release is built against an updated ocaml-vhd 0.7.3-4 library that
   corrects a bug handling lseek(2) SEEK_DATA, SEEK_HOLE.


### PR DESCRIPTION
Compile vhd-tool using new release of ocaml-vhd (v0.7.3-5) which
contains the fix for CA-218219, and also fixes CA-244698.

Signed-off-by: Frederico Mazzone <frederico.mazzone@citrix.com>